### PR TITLE
Fixed image links not working.

### DIFF
--- a/content.js
+++ b/content.js
@@ -18,3 +18,11 @@ window.addEventListener('load', event => {
 
     observer.observe(document.body, { childList: true, attributes: true })
 })
+
+document.body.addEventListener('click', e => {
+    if (e.target.nodeName !== 'UL') {
+        return
+    }
+    e.preventDefault();
+    location.href = e.target.parentElement.parentElement.href;
+})


### PR DESCRIPTION
Just redirect to the link of the parent of the parent of the unordered list they click on, which is seemingly generated and subsequently removed by Instagram on the fly.